### PR TITLE
Returning and handling a special error when mrseq file doesn't exist

### DIFF
--- a/pkg/extensionerrors/extensionerrors.go
+++ b/pkg/extensionerrors/extensionerrors.go
@@ -36,6 +36,9 @@ var (
 	// ErrNoSettingsFiles is returned if no .settings file are found
 	ErrNoSettingsFiles = errors.New("No .settings files exist")
 
+	// ErrNoMrseqFile is returned if no mrseq file are found
+	ErrNoMrseqFile = errors.New("No mrseq file exist")
+
 	ErrNotFound = errors.New("NotFound")
 
 	ErrInvalidOperationName = errors.New("operation name is invalid")

--- a/pkg/seqno/seqno_linux.go
+++ b/pkg/seqno/seqno_linux.go
@@ -15,7 +15,7 @@ func getSequenceNumberInternal(name, version string) (uint, error) {
 	mrseqStr, err := ioutil.ReadFile(mostRecentSequenceFileName)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return 0, nil
+			return 0, extensionerrors.ErrNoMrseqFile
 		}
 		return 0, fmt.Errorf("failed to read mrseq file : %s", err)
 	}

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -185,7 +185,7 @@ func getVMExtensionInternal(initInfo *InitializationInfo, manager environmentman
 	var currentSeqNo = new(uint)
 	retrievedSequenceNumber, err := manager.GetCurrentSequenceNumber(extensionLogger, &retriever, initInfo.Name, initInfo.Version)
 	if err != nil {
-		if err == extensionerrors.ErrNoSettingsFiles {
+		if err == extensionerrors.ErrNoSettingsFiles || err == extensionerrors.ErrNoMrseqFile {
 			// current sequence number could not be found, this is a special error
 			currentSeqNo = nil
 		} else {


### PR DESCRIPTION
When the mrseq file doesn't exist when enabling the extension for the first time, the extension current seqno will be 0. When running the extension's enable func, The extension's current seqno will be determined to be the same as the requested seqno which will abort the execution of the extension's enable func and exit.
From sample logs, "sequence number has not increased. Exiting." 

The change will make sure the extension's current seqno is set to null if the mrseq file doesn't exist. 