### PR TITLE
Add missing imports, Add a unit test

### DIFF
--- a/pkg/seqno/seqno_linux.go
+++ b/pkg/seqno/seqno_linux.go
@@ -2,10 +2,12 @@ package seqno
 
 import (
 	"fmt"
-	"github.com/Azure/azure-extension-platform/pkg/constants"
 	"io/ioutil"
 	"os"
 	"strconv"
+
+	"github.com/Azure/azure-extension-platform/pkg/constants"
+	"github.com/Azure/azure-extension-platform/pkg/extensionerrors"
 )
 
 var mostRecentSequenceFileName = "mrseq"

--- a/pkg/seqno/seqno_linux_test.go
+++ b/pkg/seqno/seqno_linux_test.go
@@ -1,10 +1,12 @@
 package seqno
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"os"
 	"testing"
+
+	"github.com/Azure/azure-extension-platform/pkg/extensionerrors"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_writeReadSequenceNumberFile(t *testing.T) {
@@ -14,6 +16,13 @@ func Test_writeReadSequenceNumberFile(t *testing.T) {
 	assert.NoError(t, err, "set sequence number should succeed")
 	readSeqno, err := getSequenceNumberInternal("some name", "some version")
 	assert.NoError(t, err, "get sequence number should succeed")
+	assert.Equal(t, seqno, readSeqno, "read sequence number should be same as set sequence number")
+}
+
+func Test_ReadSequenceNumberNoMrseqFile(t *testing.T) {
+	seqno := uint(0)
+	readSeqno, err := getSequenceNumberInternal("some name", "some version")
+	assert.ErrorIs(t, err, extensionerrors.ErrNoMrseqFile)
 	assert.Equal(t, seqno, readSeqno, "read sequence number should be same as set sequence number")
 }
 


### PR DESCRIPTION
It seems the import statement for extensionerrors were deleted by mistake. I'm adding the needed import statement and adding a unit test.