### PR TITLE
Ensures log messages are on separate lines

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -74,18 +74,18 @@ func (logger *ExtensionLogger) Close() {
 
 // Error logs an error. Format is the same as fmt.Print
 func (logger *ExtensionLogger) Error(format string, v ...interface{}) {
-	logger.errorLogger.Printf(format, v...)
-	logger.errorLogger.Printf(GetCallStack())
+	logger.errorLogger.Printf(format+"\n", v...)
+	logger.errorLogger.Printf(GetCallStack() + "\n")
 }
 
 // Warn logs a warning. Format is the same as fmt.Print
 func (logger *ExtensionLogger) Warn(format string, v ...interface{}) {
-	logger.warnLogger.Printf(format, v...)
+	logger.warnLogger.Printf(format+"\n", v...)
 }
 
 // Info logs an information statement. Format is the same as fmt.Print
 func (logger *ExtensionLogger) Info(format string, v ...interface{}) {
-	logger.infoLogger.Printf(format, v...)
+	logger.infoLogger.Printf(format+"\n", v...)
 }
 
 // Error logs an error. Get the message from a stream directly

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/azure-extension-platform/pkg/constants"
 	"github.com/Azure/azure-extension-platform/pkg/handlerenv"
@@ -65,8 +66,18 @@ func Test_normalTrace(t *testing.T) {
 	el.Error("we ran out of cupcakes")
 	el.Close()
 
-	dir, _ := ioutil.ReadDir(logtestdir)
-	require.Equal(t, 1, len(dir))
+	files, _ := ioutil.ReadDir(logtestdir)
+	require.Equal(t, 1, len(files))
+
+	fullpath := path.Join(logtestdir, files[0].Name())
+	bytes, err := ioutil.ReadFile(fullpath)
+	assert.NoError(t, err)
+	contents := string(bytes)
+
+	lines := strings.Split(contents, "\n")
+	assert.Contains(t, lines[0], "this is a test")
+	assert.Contains(t, lines[1], "something weird happened")
+	assert.Contains(t, lines[2], "we ran out of cupcakes")
 }
 
 func Test_loggingFromStream(t *testing.T) {


### PR DESCRIPTION
Ensures log messages are each placed on a separate line