### PR TITLE
Creating Generic Logger interface to decouple public packages from Extension Logger implementation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
-replace github.com/Azure/azure-extension-platform => /home/klugorosado/go/src/github.com/klugorosado/azure-extension-platform

--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
-

--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
+
+replace github.com/Azure/azure-extension-platform => /home/klugorosado/go/src/github.com/klugorosado/azure-extension-platform

--- a/main/sampleextension_test.go
+++ b/main/sampleextension_test.go
@@ -55,18 +55,18 @@ func (mock *mockVMExtensionEnvironmentManager) GetHandlerEnvironment(name string
 	return mock.handlerEnvironment, nil
 }
 
-func (mock *mockVMExtensionEnvironmentManager) FindSeqNum(el *logging.ExtensionLogger, configFolder string) (uint, error) {
+func (mock *mockVMExtensionEnvironmentManager) FindSeqNum(el logging.ILogger, configFolder string) (uint, error) {
 	return seqno.FindSeqNum(el, configFolder)
 }
 
-func (mock *mockVMExtensionEnvironmentManager) GetCurrentSequenceNumber(el *logging.ExtensionLogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error) {
+func (mock *mockVMExtensionEnvironmentManager) GetCurrentSequenceNumber(el logging.ILogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error) {
 	if mock.currentSeqNum == nil {
 		return 0, extensionerrors.ErrNoSettingsFiles
 	} else {
 		return *mock.currentSeqNum, nil
 	}
 }
-func (mem *mockVMExtensionEnvironmentManager) GetHandlerSettings(el *logging.ExtensionLogger, he *handlerenv.HandlerEnvironment) (*settings.HandlerSettings, error) {
+func (mem *mockVMExtensionEnvironmentManager) GetHandlerSettings(el logging.ILogger, he *handlerenv.HandlerEnvironment) (*settings.HandlerSettings, error) {
 	seqNo, err := mem.FindSeqNum(el, he.ConfigFolder)
 	if err != nil {
 		return nil, err

--- a/pkg/commandhandler/cmd.go
+++ b/pkg/commandhandler/cmd.go
@@ -13,13 +13,13 @@ import (
 )
 
 type ICommandHandler interface {
-	Execute(command string, workingDir, logDir string, waitForCompletion bool, el *logging.ExtensionLogger) (returnCode int, err error)
+	Execute(command string, workingDir, logDir string, waitForCompletion bool, el logging.ILogger) (returnCode int, err error)
 }
 type ICommandHandlerWithEnvVariables interface {
-	ExecuteWithEnvVariables(command string, workingDir, logDir string, waitForCompletion bool, el *logging.ExtensionLogger, params *map[string]string) (returnCode int, err error)
+	ExecuteWithEnvVariables(command string, workingDir, logDir string, waitForCompletion bool, el logging.ILogger, params *map[string]string) (returnCode int, err error)
 }
 
-func (commandHandler *CommandHandler) ExecuteWithEnvVariables(command string, workingDir, logDir string, waitForCompletion bool, el *logging.ExtensionLogger, params *map[string]string) (returnCode int, err error) {
+func (commandHandler *CommandHandler) ExecuteWithEnvVariables(command string, workingDir, logDir string, waitForCompletion bool, el logging.ILogger, params *map[string]string) (returnCode int, err error) {
 	return execCmdInDirWithAction(command, workingDir, logDir, waitForCompletion, el, params)
 }
 
@@ -30,7 +30,7 @@ func New() *CommandHandler {
 	return &CommandHandler{}
 }
 
-func (commandHandler *CommandHandler) Execute(command string, workingDir, logDir string, waitForCompletion bool, el *logging.ExtensionLogger) (returnCode int, err error) {
+func (commandHandler *CommandHandler) Execute(command string, workingDir, logDir string, waitForCompletion bool, el logging.ILogger) (returnCode int, err error) {
 	return execCmdInDirWithAction(command, workingDir, logDir, waitForCompletion, el, nil)
 }
 
@@ -40,7 +40,7 @@ var execDontWaitFunctionToCall func(cmd string, workingDir string) (int, error) 
 var execWaitFunctionWithParams = execWaitWithEnvVariables
 var execDontWaitFunctionWithParams = execDontWaitWithEnvVariables
 
-func execCmdInDirWithAction(cmd, workingDir, logDir string, waitForCompletion bool, el *logging.ExtensionLogger, params *map[string]string) (int, error) {
+func execCmdInDirWithAction(cmd, workingDir, logDir string, waitForCompletion bool, el logging.ILogger, params *map[string]string) (int, error) {
 	var exitCode int
 	var execErr error
 	err := os.MkdirAll(workingDir, constants.FilePermissions_UserOnly_ReadWriteExecute)

--- a/pkg/environmentmanager/environmentmanager.go
+++ b/pkg/environmentmanager/environmentmanager.go
@@ -12,8 +12,8 @@ import (
 // Allows for mocking all environment operations when running tests against VM extensions
 type IGetVMExtensionEnvironmentManager interface {
 	GetHandlerEnvironment(name string, version string) (*handlerenv.HandlerEnvironment, error)
-	FindSeqNum(el *logging.ExtensionLogger, configFolder string) (uint, error)
-	GetCurrentSequenceNumber(el *logging.ExtensionLogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error)
-	GetHandlerSettings(el *logging.ExtensionLogger, he *handlerenv.HandlerEnvironment) (*settings.HandlerSettings, error)
+	FindSeqNum(el logging.ILogger, configFolder string) (uint, error)
+	GetCurrentSequenceNumber(el logging.ILogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error)
+	GetHandlerSettings(el logging.ILogger, he *handlerenv.HandlerEnvironment) (*settings.HandlerSettings, error)
 	SetSequenceNumberInternal(extensionName, extensionVersion string, seqNo uint) error
 }

--- a/pkg/extensionevents/extension_events.go
+++ b/pkg/extensionevents/extension_events.go
@@ -37,7 +37,7 @@ type extensionEvent struct {
 // ExtensionEventManager allows extensions to log events that will be collected
 // by the Guest Agent
 type ExtensionEventManager struct {
-	extensionLogger *logging.ExtensionLogger
+	extensionLogger logging.ILogger
 	eventsFolder    string
 	operationID     string
 }
@@ -81,7 +81,7 @@ func (eem *ExtensionEventManager) logEvent(taskName string, eventLevel string, m
 }
 
 // New creates a new instance of the ExtensionEventManager
-func New(el *logging.ExtensionLogger, he *handlerenv.HandlerEnvironment) *ExtensionEventManager {
+func New(el logging.ILogger, he *handlerenv.HandlerEnvironment) *ExtensionEventManager {
 	eem := &ExtensionEventManager{
 		extensionLogger: el,
 		eventsFolder:    he.EventsFolder,

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -33,6 +33,21 @@ const (
 	logDirThresholdHigh = fortyMB
 )
 
+type StreamLogReader interface {
+	ErrorFromStream(prefix string, streamReader io.Reader)
+	WarnFromStream(prefix string, streamReader io.Reader)
+	InfoFromStream(prefix string, streamReader io.Reader)
+}
+
+// Target interface for Extentsion-Platform
+type ILogger interface {
+	StreamLogReader
+	Error(format string, v ...interface{})
+	Warn(format string, v ...interface{})
+	Info(format string, v ...interface{})
+	Close()
+}
+
 // ExtensionLogger exposes logging capabilities to the extension
 // It automatically appends time stamps and debug level to each message
 // and ensures all logs are placed in the logs folder passed by the agent

--- a/pkg/seqno/seqno.go
+++ b/pkg/seqno/seqno.go
@@ -29,7 +29,7 @@ func (*ProdSequenceNumberRetriever) GetSequenceNumber(name, version string) (uin
 }
 
 // GetCurrentSequenceNumber returns the current sequence number the extension is using
-func GetCurrentSequenceNumber(el *logging.ExtensionLogger, retriever ISequenceNumberRetriever, name, version string) (sn uint, _ error) {
+func GetCurrentSequenceNumber(el logging.ILogger, retriever ISequenceNumberRetriever, name, version string) (sn uint, _ error) {
 	sequenceNumber, err := retriever.GetSequenceNumber(name, version)
 	if err == extensionerrors.ErrNotFound || err == extensionerrors.ErrNoMrseqFile {
 		// If we can't find the sequence number, then it's possible that the extension
@@ -47,7 +47,7 @@ func SetSequenceNumber(extName, extVersion string, seqNo uint) error {
 
 // findSeqnum finds the most recently used file under the config folder
 // Note that this is different than just choosing the highest number, which may be incorrect
-func FindSeqNum(el *logging.ExtensionLogger, configFolder string) (uint, error) {
+func FindSeqNum(el logging.ILogger, configFolder string) (uint, error) {
 	// try getting the sequence number from the environment first
 	seqNoString := os.Getenv(configSequenceNumber)
 	if seqNoString == "" {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -46,7 +46,7 @@ type handlerSettingsContainer struct {
 }
 
 // GetHandlerSettings reads and parses the handler's settings in an OS independent manner
-func GetHandlerSettings(el *logging.ExtensionLogger, he *handlerenv.HandlerEnvironment, seqNo uint) (hs *HandlerSettings, _ error) {
+func GetHandlerSettings(el logging.ILogger, he *handlerenv.HandlerEnvironment, seqNo uint) (hs *HandlerSettings, _ error) {
 	// The file will be under the config folder with the path {seqNo}.settings
 	settingsFileName := filepath.Join(he.ConfigFolder, fmt.Sprintf("%d%s", seqNo, settingsFileSuffix))
 	parsedHs, err := parseHandlerSettingsFile(el, settingsFileName)
@@ -80,7 +80,7 @@ func GetHandlerSettings(el *logging.ExtensionLogger, he *handlerenv.HandlerEnvir
 // unmarshalProtectedSettings decodes the protected settings from handler
 // runtime settings JSON file, decrypts it using the certificates and unmarshals
 // into the given struct v.
-func unmarshalProtectedSettings(el *logging.ExtensionLogger, configFolder string, hs handlerSettings) (string, error) {
+func unmarshalProtectedSettings(el logging.ILogger, configFolder string, hs handlerSettings) (string, error) {
 	if hs.ProtectedSettingsBase64 == "" {
 		// No protected settings
 		return "", nil
@@ -102,7 +102,7 @@ func unmarshalProtectedSettings(el *logging.ExtensionLogger, configFolder string
 
 // parseHandlerSettings parses a handler settings file (e.g. 0.settings) and
 // returns it as a structured object.
-func parseHandlerSettingsFile(el *logging.ExtensionLogger, path string) (h handlerSettings, _ error) {
+func parseHandlerSettingsFile(el logging.ILogger, path string) (h handlerSettings, _ error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		el.Error("parseHandlerSettingsFile failed. Error reading %s: %v", path, err)
@@ -127,7 +127,7 @@ func parseHandlerSettingsFile(el *logging.ExtensionLogger, path string) (h handl
 
 // CleanUpSettings replaces the protected settings for all settings files [ex: 0.settings, etc] to ensure no
 // protected settings are logged in VM
-func CleanUpSettings(el *logging.ExtensionLogger, configFolder string) {
+func CleanUpSettings(el logging.ILogger, configFolder string) {
 	configDir, err := ioutil.ReadDir(configFolder)
 	if err != nil {
 		el.Error("error clearing config file: %v", err)

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -108,15 +108,15 @@ func (*prodGetVMExtensionEnvironmentManager) GetHandlerEnvironment(name string, 
 	return handlerenv.GetHandlerEnvironment(name, version)
 }
 
-func (*prodGetVMExtensionEnvironmentManager) FindSeqNum(el *logging.ExtensionLogger, configFolder string) (uint, error) {
+func (*prodGetVMExtensionEnvironmentManager) FindSeqNum(el logging.ILogger, configFolder string) (uint, error) {
 	return seqno.FindSeqNum(el, configFolder)
 }
 
-func (*prodGetVMExtensionEnvironmentManager) GetCurrentSequenceNumber(el *logging.ExtensionLogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error) {
+func (*prodGetVMExtensionEnvironmentManager) GetCurrentSequenceNumber(el logging.ILogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error) {
 	return seqno.GetCurrentSequenceNumber(el, retriever, name, version)
 }
 
-func (em *prodGetVMExtensionEnvironmentManager) GetHandlerSettings(el *logging.ExtensionLogger, he *handlerenv.HandlerEnvironment) (*settings.HandlerSettings, error) {
+func (em *prodGetVMExtensionEnvironmentManager) GetHandlerSettings(el logging.ILogger, he *handlerenv.HandlerEnvironment) (*settings.HandlerSettings, error) {
 	seqNo, err := em.FindSeqNum(el, he.ConfigFolder)
 	if err != nil {
 		return nil, err

--- a/vmextension/vmextension_test.go
+++ b/vmextension/vmextension_test.go
@@ -53,7 +53,7 @@ func (mm *mockGetVMExtensionEnvironmentManager) GetHandlerEnvironment(name strin
 	return mm.he, nil
 }
 
-func (mm *mockGetVMExtensionEnvironmentManager) FindSeqNum(el *logging.ExtensionLogger, configFolder string) (uint, error) {
+func (mm *mockGetVMExtensionEnvironmentManager) FindSeqNum(el logging.ILogger, configFolder string) (uint, error) {
 	if mm.findSeqNumError != nil {
 		return 0, mm.findSeqNumError
 	}
@@ -61,7 +61,7 @@ func (mm *mockGetVMExtensionEnvironmentManager) FindSeqNum(el *logging.Extension
 	return mm.seqNo, nil
 }
 
-func (mm *mockGetVMExtensionEnvironmentManager) GetCurrentSequenceNumber(el *logging.ExtensionLogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error) {
+func (mm *mockGetVMExtensionEnvironmentManager) GetCurrentSequenceNumber(el logging.ILogger, retriever seqno.ISequenceNumberRetriever, name, version string) (uint, error) {
 	if mm.getCurrentSequenceNumberError != nil {
 		return 0, mm.getCurrentSequenceNumberError
 	}
@@ -69,7 +69,7 @@ func (mm *mockGetVMExtensionEnvironmentManager) GetCurrentSequenceNumber(el *log
 	return mm.currentSeqNo, nil
 }
 
-func (mm *mockGetVMExtensionEnvironmentManager) GetHandlerSettings(el *logging.ExtensionLogger, he *handlerenv.HandlerEnvironment) (hs *settings.HandlerSettings, _ error) {
+func (mm *mockGetVMExtensionEnvironmentManager) GetHandlerSettings(el logging.ILogger, he *handlerenv.HandlerEnvironment) (hs *settings.HandlerSettings, _ error) {
 	if mm.getHandlerSettingsError != nil {
 		return hs, mm.getHandlerSettingsError
 	}


### PR DESCRIPTION
This pulls request primarily involves a refactoring of the logging interface in the codebase. The changes replace the usage of `*logging.ExtensionLogger` with `logging.ILogger` throughout multiple files. This change will enhance code flexibility and testability, it will also provide other Azure VM Extension developers with the ability to pass around their own Extension Logger implementations. 

Here are the most significant changes:

Refactoring of logging interface:

* [`pkg/logging/logging.go`](diffhunk://#diff-eb19031b20f577302a6bfbcbb42ee60f37256f9ed2044d905a7aa681309bca69R36-R50): Introduced a new interface `ILogger` and `StreamLogReader` for logging operations. This change is a key part of this pull request as it forms the basis for the modifications in the other files.

* `main/sampleextension_test.go`, `pkg/commandhandler/cmd.go`, `pkg/environmentmanager/environmentmanager.go`, `pkg/extensionevents/extension_events.go`, `pkg/seqno/seqno.go`, `pkg/settings/settings.go`, `vmextension/vmextension.go`, `vmextension/vmextension_test.go`: Replaced the usage of `*logging.ExtensionLogger` with `logging.ILogger` in function parameters. This change aligns with the new logging interface introduced. [[1]](diffhunk://#diff-8d66101511071f47d7b6432ba925a6beba26ad7d3faea65fff10c9a2864688c7L58-R69) [[2]](diffhunk://#diff-58aefa1039eec5252b0c0211113a86071908dc9dd6d8a8a539331048231f247fL16-R22) [[3]](diffhunk://#diff-5556732dbda70ab9ededb7dca5505b30a35272c8e57bd3babe209d3fdea34484L15-R17) [[4]](diffhunk://#diff-033d7e97e60e493481f7349120495d7fb8c93be13d1002d75dd750ade3122678L40-R40) [[5]](diffhunk://#diff-5a93168dd3ec5709e0c4e4191688724221b839ccaa2f9307d891bd3e6a5c77d8L32-R32) [[6]](diffhunk://#diff-48e0baf08b9012e1ff8424004af6ba1034eabbe4c9e6696efc65424b57df96d0L49-R49) [[7]](diffhunk://#diff-c4363e6b9c60e86e4c55f90fc7eb11aefcb78dbad9cbc0836a99388ee7cc6f13L111-R119) [[8]](diffhunk://#diff-9cdfadcef4271c5cc4e7aa9efd97a4b7736dfd57f93cec5b8510e7b9521c7449L56-R72)

Please review these changes and let me know if you have any questions or need further explanations.