### PR TITLE
Use RFC3339Nano for better timestamp precision in extension events

### DIFF
--- a/pkg/extensionevents/extension_events.go
+++ b/pkg/extensionevents/extension_events.go
@@ -49,7 +49,7 @@ func (eem *ExtensionEventManager) logEvent(taskName string, eventLevel string, m
 	}
 
 	extensionVersion := os.Getenv("AZURE_GUEST_AGENT_EXTENSION_VERSION")
-	timestamp := time.Now().UTC().Format(time.RFC3339)
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
 	pid := fmt.Sprintf("%v", os.Getpid())
 	tid := getThreadID()
 


### PR DESCRIPTION
Extension events are currently in format RFC3339, which is in format yyyy-mm-ddThh:mm:ssZ. We should use RFC3339Nano instead so the logs can be sorted correctly with milliseconds/nanosecond precision.