### PR TITLE
Capture StdErr in command execution error

### DIFF
--- a/pkg/commandhandler/cmd.go
+++ b/pkg/commandhandler/cmd.go
@@ -3,13 +3,14 @@
 package commandhandler
 
 import (
-	"github.com/Azure/azure-extension-platform/pkg/constants"
-	"github.com/Azure/azure-extension-platform/pkg/logging"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/Azure/azure-extension-platform/pkg/constants"
+	"github.com/Azure/azure-extension-platform/pkg/logging"
+	"github.com/pkg/errors"
 )
 
 type ICommandHandler interface {
@@ -70,10 +71,13 @@ func execCmdInDirWithAction(cmd, workingDir, logDir string, waitForCompletion bo
 			stdOutFile.Close()
 		}
 
-		stdErrFile, err3 := os.OpenFile(errFileName, os.O_RDONLY, constants.FilePermissions_UserOnly_ReadWrite)
+		stdErrContents, err3 := os.ReadFile(errFileName)
 		if err3 == nil {
-			el.InfoFromStream("stderr:", stdErrFile)
-			stdErrFile.Close()
+			el.Info("stderr: %s", stdErrContents)
+
+			if execErr != nil {
+				return exitCode, errors.Wrap(execErr, string(stdErrContents))
+			}
 		}
 
 	} else {

--- a/pkg/commandhandler/cmd_linux_test.go
+++ b/pkg/commandhandler/cmd_linux_test.go
@@ -4,11 +4,13 @@ package commandhandler
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -96,4 +98,17 @@ func TestCommandWithEnvironmentVariableEmpty(t *testing.T) {
 	fileInfo, err := ioutil.ReadFile(path.Join(workingDir, "stdout"))
 	assert.NoError(t, err, "stdout file should be read")
 	assert.Contains(t, string(fileInfo), "", "stdout message should be as expected")
+}
+
+func TestNonExistingCommand(t *testing.T) {
+	defer cleanupTest()
+	cmd := New()
+	retcode, err := cmd.Execute("command_does_not_exist", workingDir, workingDir, true, extensionLogger)
+	assert.Equal(t, commandNotExistReturnCode, retcode)
+	assert.Error(t, err, "command execution should fail")
+	assert.Contains(t, err.Error(), "command_does_not_exist: not found", "error returned by cmd.Execute should include stderr")
+
+	fileInfo, err := os.ReadFile(path.Join(workingDir, "stderr"))
+	assert.NoError(t, err, "stderr file should be read")
+	assert.Contains(t, string(fileInfo), "command_does_not_exist: not found", "stderr message should be as expected")
 }

--- a/pkg/commandhandler/cmd_test.go
+++ b/pkg/commandhandler/cmd_test.go
@@ -44,16 +44,3 @@ func TestStderr(t *testing.T) {
 	stdoutResult := strings.TrimSuffix(strings.TrimSuffix(string(fileBytes), lineReturnCharacter), " ")
 	assert.Equal(t, "1 2 3 4", stdoutResult)
 }
-
-func TestNonExistingCommand(t *testing.T) {
-	defer cleanupTest()
-	cmd := New()
-	retcode, err := cmd.Execute("command_does_not_exist", workingDir, workingDir, true, extensionLogger)
-	assert.Equal(t, commandNotExistReturnCode, retcode)
-	assert.Error(t, err, "command execution should fail")
-	assert.Contains(t, err.Error(), "is not recognized as an internal or external command", "error returned by cmd.Execute should include stderr")
-
-	fileInfo, err := os.ReadFile(path.Join(workingDir, "stderr"))
-	assert.NoError(t, err, "stderr file should be read")
-	assert.Contains(t, string(fileInfo), "is not recognized as an internal or external command", "stderr message should be as expected")
-}

--- a/pkg/commandhandler/cmd_test.go
+++ b/pkg/commandhandler/cmd_test.go
@@ -3,13 +3,14 @@
 package commandhandler
 
 import (
-	"github.com/Azure/azure-extension-platform/pkg/logging"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/Azure/azure-extension-platform/pkg/logging"
+	"github.com/stretchr/testify/assert"
 )
 
 var workingDir = path.Join(".", "testdir", "currentWorkingDir")
@@ -49,5 +50,10 @@ func TestNonExistingCommand(t *testing.T) {
 	cmd := New()
 	retcode, err := cmd.Execute("command_does_not_exist", workingDir, workingDir, true, extensionLogger)
 	assert.Equal(t, commandNotExistReturnCode, retcode)
-	assert.Error(t, err)
+	assert.Error(t, err, "command execution should fail")
+	assert.Contains(t, err.Error(), "is recognized as an internal or external command", "error returned by cmd.Execute should include stderr")
+
+	fileInfo, err := os.ReadFile(path.Join(workingDir, "stderr"))
+	assert.NoError(t, err, "stderr file should be read")
+	assert.Contains(t, string(fileInfo), "is not recognized as an internal or external command", "stderr message should be as expected")
 }

--- a/pkg/commandhandler/cmd_test.go
+++ b/pkg/commandhandler/cmd_test.go
@@ -51,7 +51,7 @@ func TestNonExistingCommand(t *testing.T) {
 	retcode, err := cmd.Execute("command_does_not_exist", workingDir, workingDir, true, extensionLogger)
 	assert.Equal(t, commandNotExistReturnCode, retcode)
 	assert.Error(t, err, "command execution should fail")
-	assert.Contains(t, err.Error(), "is recognized as an internal or external command", "error returned by cmd.Execute should include stderr")
+	assert.Contains(t, err.Error(), "is not recognized as an internal or external command", "error returned by cmd.Execute should include stderr")
 
 	fileInfo, err := os.ReadFile(path.Join(workingDir, "stderr"))
 	assert.NoError(t, err, "stderr file should be read")

--- a/pkg/commandhandler/cmd_windows_test.go
+++ b/pkg/commandhandler/cmd_windows_test.go
@@ -4,12 +4,13 @@ package commandhandler
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -139,4 +140,17 @@ func TestDoesntWaitForCompletionEnvironmentVariable(t *testing.T) {
 	endTime := time.Now()
 	duration := endTime.Sub(startTime)
 	assert.Less(t, duration, time.Second, "execute shouldn't block")
+}
+
+func TestNonExistingCommand(t *testing.T) {
+	defer cleanupTest()
+	cmd := New()
+	retcode, err := cmd.Execute("command_does_not_exist", workingDir, workingDir, true, extensionLogger)
+	assert.Equal(t, commandNotExistReturnCode, retcode)
+	assert.Error(t, err, "command execution should fail")
+	assert.Contains(t, err.Error(), "is not recognized as an internal or external command", "error returned by cmd.Execute should include stderr")
+
+	fileInfo, err := os.ReadFile(path.Join(workingDir, "stderr"))
+	assert.NoError(t, err, "stderr file should be read")
+	assert.Contains(t, string(fileInfo), "is not recognized as an internal or external command", "stderr message should be as expected")
 }


### PR DESCRIPTION
Currently, StdOut and StdErr are not captured in Kusto logs or failures for VMApps extension operations (executing install/update/remove commands for VMApps). They are however logged to the in-VM log folders.

The change here captures StdErr as part of the overall execution error for a command which is then returned to the caller of the Execute command, providing them with a more descriptive error.

In the case of the VMApps extension, it will then be able to log this error within the extension events that are collected by the Guest Agent and are displayed in Kusto. This error would also be used within the status reported by the extension for the specific application for which the command failed.