### PR TITLE
Adds support for user errors to the extensions platform

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -67,10 +67,9 @@ type Status struct {
 }
 
 type Substatus struct {
-	Name    string `json:"name"`
-	Status  string `json:"status"`
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Code   int    `json:"code"`
 }
 
 // FormattedMessage is a struct used for serializing status
@@ -109,10 +108,9 @@ func NewError(operation string, ec ErrorClarification) StatusReport {
 					Message: ec.Message},
 				Substatuses: []Substatus{
 					{
-						Name:    ErrorClarificationSubStatusName,
-						Status:  "error",
-						Code:    ec.Code,
-						Message: ec.Message,
+						Name:   ErrorClarificationSubStatusName,
+						Status: string(StatusError),
+						Code:   ec.Code,
 					},
 				},
 			},

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -4,10 +4,11 @@ package status
 
 import (
 	"encoding/json"
-	"github.com/Azure/azure-extension-platform/pkg/testhelpers"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
+
+	"github.com/Azure/azure-extension-platform/pkg/testhelpers"
 
 	"github.com/stretchr/testify/require"
 )
@@ -49,6 +50,18 @@ func Test_newStatus(t *testing.T) {
 	require.Equal(t, StatusError, report[0].Status.Status)
 }
 
+func Test_newError(t *testing.T) {
+	ec := ErrorClarification{Code: 42, Message: "unhappy chipmunks"}
+	report := NewError("WorldDomination", ec)
+	require.NotNil(t, report)
+	require.Equal(t, 1, len(report))
+	require.Equal(t, "WorldDomination", report[0].Status.Operation)
+	require.Equal(t, StatusError, report[0].Status.Status)
+	require.Equal(t, 1, len(report[0].Status.Substatuses))
+	require.Equal(t, 42, report[0].Status.Substatuses[0].Code)
+	require.Equal(t, "unhappy chipmunks", report[0].Status.Substatuses[0].Message)
+}
+
 func Test_statusSaveFolderDoesntExist(t *testing.T) {
 	report := New(StatusSuccess, "flip", "flop")
 	err := report.Save("./flopperdoodle", 5)
@@ -62,7 +75,7 @@ func Test_statusSaveNewFile(t *testing.T) {
 	require.NoError(t, err, "save report failed")
 
 	filePath := path.Join(statusTestDirectory, "5.status")
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	require.NoError(t, err, "ReadFile failed")
 
 	var r StatusReport

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -59,7 +59,6 @@ func Test_newError(t *testing.T) {
 	require.Equal(t, StatusError, report[0].Status.Status)
 	require.Equal(t, 1, len(report[0].Status.Substatuses))
 	require.Equal(t, 42, report[0].Status.Substatuses[0].Code)
-	require.Equal(t, "unhappy chipmunks", report[0].Status.Substatuses[0].Message)
 }
 
 func Test_statusSaveFolderDoesntExist(t *testing.T) {

--- a/vmextension/enabledisable.go
+++ b/vmextension/enabledisable.go
@@ -32,14 +32,14 @@ func enable(ext *VMExtension) (string, error) {
 	if !exists {
 		msg := "extension does not have an enable command"
 		ext.ExtensionLogger.Error(msg)
-		reportError(ext, enableCmd, ErrorNoSequenceNumber, msg)
+		reportErrorWithClarification(ext, enableCmd, ErrorNoSequenceNumber, msg)
 		return msg, fmt.Errorf(msg)
 	}
 	requestedSequenceNumber, err := ext.GetRequestedSequenceNumber()
 	if err != nil {
 		msg := "could not determine requested sequence number"
 		ext.ExtensionLogger.Error("%s: %v", msg, err)
-		reportError(ext, enableCmd, ErrorUnparseableSeqNo, err.Error()+msg)
+		reportErrorWithClarification(ext, enableCmd, ErrorUnparseableSeqNo, err.Error()+msg)
 		return msg, err
 	}
 
@@ -86,7 +86,7 @@ func enable(ext *VMExtension) (string, error) {
 
 		if supportsEwc {
 			// The extension supports error clarifications
-			reportError(ext, enableCmd, ewc.ErrorCode, msgToReport)
+			reportErrorWithClarification(ext, enableCmd, ewc.ErrorCode, msgToReport)
 		} else {
 			// The extension does not support error clarifications
 			reportStatus(ext, status.StatusError, enableCmd, msgToReport)

--- a/vmextension/enabledisable.go
+++ b/vmextension/enabledisable.go
@@ -4,7 +4,6 @@ package vmextension
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
@@ -20,6 +19,11 @@ var (
 	disableDependency disableDependencies = &disableDependencyImpl{}
 )
 
+const (
+	ErrorNoSequenceNumber = -10001
+	ErrorUnparseableSeqNo = -10002
+)
+
 func enable(ext *VMExtension) (string, error) {
 	// If the sequence number has not changed and we require it to, then exit
 	// remember the sequence number
@@ -28,14 +32,14 @@ func enable(ext *VMExtension) (string, error) {
 	if !exists {
 		msg := "extension does not have an enable command"
 		ext.ExtensionLogger.Error(msg)
-		reportStatus(ext, status.StatusError, enableCmd, msg)
+		reportError(ext, enableCmd, ErrorNoSequenceNumber, msg)
 		return msg, fmt.Errorf(msg)
 	}
 	requestedSequenceNumber, err := ext.GetRequestedSequenceNumber()
 	if err != nil {
 		msg := "could not determine requested sequence number"
 		ext.ExtensionLogger.Error("%s: %v", msg, err)
-		reportStatus(ext, status.StatusError, enableCmd, err.Error()+msg)
+		reportError(ext, enableCmd, ErrorUnparseableSeqNo, err.Error()+msg)
 		return msg, err
 	}
 
@@ -67,14 +71,26 @@ func enable(ext *VMExtension) (string, error) {
 	// execute the command, save its error
 	msg, runErr := ext.exec.enableCallback(ext)
 	if runErr != nil {
-		ext.ExtensionLogger.Error("Enable failed: %v", runErr)
+		unifiedErr := runErr
+		ewc, supportsEwc := runErr.(ErrorWithClarification)
+		if supportsEwc {
+			unifiedErr = ewc.Err
+		}
+		ext.ExtensionLogger.Error("Enable failed: %v", unifiedErr)
 		var msgToReport string
 		if msg == "" {
-			msgToReport = runErr.Error()
+			msgToReport = unifiedErr.Error()
 		} else {
 			msgToReport = msg
 		}
-		reportStatus(ext, status.StatusError, enableCmd, msgToReport)
+
+		if supportsEwc {
+			// The extension supports error clarifications
+			reportError(ext, enableCmd, ewc.ErrorCode, msgToReport)
+		} else {
+			// The extension does not support error clarifications
+			reportStatus(ext, status.StatusError, enableCmd, msgToReport)
+		}
 	} else {
 		ext.ExtensionLogger.Info("Enable succeeded")
 		reportStatus(ext, status.StatusSuccess, enableCmd, msg)
@@ -91,7 +107,7 @@ type disableDependencies interface {
 type disableDependencyImpl struct{}
 
 func (*disableDependencyImpl) writeFile(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 func (*disableDependencyImpl) remove(name string) error {

--- a/vmextension/errorwithclarification.go
+++ b/vmextension/errorwithclarification.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package vmextension
+
+type ErrorWithClarification struct {
+	ErrorCode int
+	Err       error
+}
+
+func (ewc ErrorWithClarification) Error() string {
+	return ewc.Err.Error()
+}
+
+func NewErrorWithClarification(errorCode int, err error) ErrorWithClarification {
+	return ErrorWithClarification{
+		ErrorCode: errorCode,
+		Err:       err,
+	}
+}

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -289,7 +289,7 @@ func reportStatus(ve *VMExtension, t status.StatusType, c cmd, msg string) error
 	return nil
 }
 
-func reportError(ve *VMExtension, c cmd, errorCode int, msg string) error {
+func reportErrorWithClarification(ve *VMExtension, c cmd, errorCode int, msg string) error {
 	if !c.shouldReportStatus {
 		ve.ExtensionLogger.Info("status not reported for operation (by design)")
 		return nil

--- a/vmextension/vmextension_test.go
+++ b/vmextension/vmextension_test.go
@@ -5,7 +5,6 @@ package vmextension
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -97,6 +96,18 @@ func Test_reportStatusShouldntReport(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "File exists when we don't expect it to")
 }
 
+func Test_reportErrorShouldntReport(t *testing.T) {
+	ext := createTestVMExtension()
+	c := cmd{nil, InstallOperation, false, 99}
+	ext.HandlerEnv.StatusFolder = statusTestDirectory
+	ext.GetRequestedSequenceNumber = func() (uint, error) { return 45, nil }
+
+	err := reportError(ext, c, 42, "msg")
+	require.NoError(t, err, "reportError failed")
+	_, err = os.Stat(path.Join(statusTestDirectory, "45.status"))
+	require.True(t, os.IsNotExist(err), "File exists when we don't expect it to")
+}
+
 func Test_reportStatusCouldntSave(t *testing.T) {
 	ext := createTestVMExtension()
 	c := cmd{nil, InstallOperation, true, 99}
@@ -104,6 +115,16 @@ func Test_reportStatusCouldntSave(t *testing.T) {
 	ext.GetRequestedSequenceNumber = func() (uint, error) { return 45, nil }
 
 	err := reportStatus(ext, status.StatusSuccess, c, "msg")
+	require.Error(t, err)
+}
+
+func Test_reportErrorCouldntSave(t *testing.T) {
+	ext := createTestVMExtension()
+	c := cmd{nil, InstallOperation, true, 99}
+	ext.HandlerEnv.StatusFolder = "./yabamonster"
+	ext.GetRequestedSequenceNumber = func() (uint, error) { return 45, nil }
+
+	err := reportError(ext, c, 42, "msg")
 	require.Error(t, err)
 }
 
@@ -119,6 +140,22 @@ func Test_reportStatusSaved(t *testing.T) {
 
 	err := reportStatus(ext, status.StatusSuccess, c, "msg")
 	require.NoError(t, err, "reportStatus failed")
+	_, err = os.Stat(path.Join(statusTestDirectory, "45.status"))
+	require.NoError(t, err, "File doesn't exist")
+}
+
+func Test_reportErrorSaved(t *testing.T) {
+	ext := createTestVMExtension()
+
+	c := cmd{nil, InstallOperation, true, 99}
+	ext.HandlerEnv.StatusFolder = statusTestDirectory
+	ext.GetRequestedSequenceNumber = func() (uint, error) { return 45, nil }
+
+	createDirsForVMExtension(ext)
+	defer cleanupDirsForVMExtension(ext)
+
+	err := reportError(ext, c, 42, "msg")
+	require.NoError(t, err, "reportError failed")
 	_, err = os.Stat(path.Join(statusTestDirectory, "45.status"))
 	require.NoError(t, err, "File doesn't exist")
 }
@@ -142,7 +179,7 @@ func Test_reportStatusFormatter(t *testing.T) {
 	statusFilePath := path.Join(statusTestDirectory, "45.status")
 	_, err = os.Stat(statusFilePath)
 	require.NoError(t, err, "File doesn't exist")
-	statusFileBytes, err := ioutil.ReadFile(statusFilePath)
+	statusFileBytes, err := os.ReadFile(statusFilePath)
 	require.NoError(t, err, "Could not read status file contents")
 	require.Contains(t, string(statusFileBytes), customFormattedMessage)
 }
@@ -414,6 +451,18 @@ func Test_enableCallbackFails(t *testing.T) {
 	require.Equal(t, extensionerrors.ErrMustRunAsAdmin, err)
 }
 
+func Test_enableCallbackErrorClarification(t *testing.T) {
+	mm := createMockVMExtensionEnvironmentManager()
+	ii, _ := GetInitializationInfo("yaba", "5.0", true, testErrorClarificationEnableCallback)
+	ext, _ := getVMExtensionInternal(ii, mm)
+
+	_, err := enable(ext)
+	ewc, ok := err.(ErrorWithClarification)
+	require.True(t, ok, "ErrorWithClarification not returned")
+	require.Equal(t, 42, ewc.ErrorCode)
+	require.Equal(t, extensionerrors.ErrArgCannotBeNullOrEmpty, ewc.Err)
+}
+
 func Test_enableCallbackSucceeds(t *testing.T) {
 	mm := createMockVMExtensionEnvironmentManager()
 	ii, _ := GetInitializationInfo("yaba", "5.0", true, testEnableCallback)
@@ -576,7 +625,7 @@ func writeHandlerEnvironment(t *testing.T, rawhe string) {
 	d := []byte(rawhe)
 	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 	fp := path.Join(dir, handlerEnvFileName)
-	err := ioutil.WriteFile(fp, d, 0644)
+	err := os.WriteFile(fp, d, 0644)
 	require.NoError(t, err)
 }
 
@@ -592,6 +641,10 @@ func putBackArgs(args []string) {
 
 func testFailEnableCallback(ext *VMExtension) (string, error) {
 	return "", extensionerrors.ErrMustRunAsAdmin
+}
+
+func testErrorClarificationEnableCallback(ext *VMExtension) (string, error) {
+	return "", NewErrorWithClarification(42, extensionerrors.ErrArgCannotBeNullOrEmpty)
 }
 
 func getTestHandlerEnvironment() *handlerenv.HandlerEnvironment {

--- a/vmextension/vmextension_test.go
+++ b/vmextension/vmextension_test.go
@@ -102,7 +102,7 @@ func Test_reportErrorShouldntReport(t *testing.T) {
 	ext.HandlerEnv.StatusFolder = statusTestDirectory
 	ext.GetRequestedSequenceNumber = func() (uint, error) { return 45, nil }
 
-	err := reportError(ext, c, 42, "msg")
+	err := reportErrorWithClarification(ext, c, 42, "msg")
 	require.NoError(t, err, "reportError failed")
 	_, err = os.Stat(path.Join(statusTestDirectory, "45.status"))
 	require.True(t, os.IsNotExist(err), "File exists when we don't expect it to")
@@ -124,7 +124,7 @@ func Test_reportErrorCouldntSave(t *testing.T) {
 	ext.HandlerEnv.StatusFolder = "./yabamonster"
 	ext.GetRequestedSequenceNumber = func() (uint, error) { return 45, nil }
 
-	err := reportError(ext, c, 42, "msg")
+	err := reportErrorWithClarification(ext, c, 42, "msg")
 	require.Error(t, err)
 }
 
@@ -154,7 +154,7 @@ func Test_reportErrorSaved(t *testing.T) {
 	createDirsForVMExtension(ext)
 	defer cleanupDirsForVMExtension(ext)
 
-	err := reportError(ext, c, 42, "msg")
+	err := reportErrorWithClarification(ext, c, 42, "msg")
 	require.NoError(t, err, "reportError failed")
 	_, err = os.Stat(path.Join(statusTestDirectory, "45.status"))
 	require.NoError(t, err, "File doesn't exist")


### PR DESCRIPTION
Supports UserErrors, which inform CRP whether the extension failed due to a fault of the customer or due to an extension/internal error. 

Extensions simply need to raise an ErrorWithException containing the actual error and the correct substatus will be reported. This is only supported for Enable for now.