### PR TITLE
Added function to retrieve Environment variables set by the guest agent.

### DIFF
--- a/pkg/lockedfile/lockedfile_test.go
+++ b/pkg/lockedfile/lockedfile_test.go
@@ -31,6 +31,7 @@ func TestLockFileMetadata(t *testing.T) {
 	var lf ILockedFile
 	lf, err := New(testFilePath, time.Second)
 	assert.NoError(t, err)
+	time.Sleep(time.Second)
 	lf.Close()
 	lastOpened, lastClosed, err := getLastOpenedAndLastClosedTime(testFilePath)
 	assert.NoError(t, err)

--- a/pkg/lockedfile/lockedfile_windows.go
+++ b/pkg/lockedfile/lockedfile_windows.go
@@ -3,9 +3,10 @@
 package lockedfile
 
 import (
-	"golang.org/x/sys/windows"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -137,8 +138,6 @@ func (self *lockedFile) WriteLockedFile(bytes []byte) error {
 	default:
 		return err
 	}
-
-	return nil
 }
 
 func (self *lockedFile) closeInner() error {

--- a/pkg/lockedfile/lockedfile_windows.go
+++ b/pkg/lockedfile/lockedfile_windows.go
@@ -3,10 +3,9 @@
 package lockedfile
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"time"
-
-	"golang.org/x/sys/windows"
 )
 
 const (
@@ -138,6 +137,8 @@ func (self *lockedFile) WriteLockedFile(bytes []byte) error {
 	default:
 		return err
 	}
+
+	return nil
 }
 
 func (self *lockedFile) closeInner() error {

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -144,7 +144,7 @@ func (*prodGetVMExtensionEnvironmentManager) SetSequenceNumberInternal(extension
 	return seqno.SetSequenceNumber(extensionName, extensionVersion, seqNo)
 }
 
-func GuestAgentEnvironmetVariable(envVarName GuestAgentEnvVar) (string, error) {
+func GetGuestAgentEnvironmetVariable(envVarName GuestAgentEnvVar) (string, error) {
 	extensionVersion, isSet := os.LookupEnv(string(envVarName))
 	if !isSet || extensionVersion == "" {
 		return "", errors.Errorf("Extension environment variable '%s' is not set", envVarName)

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -27,6 +27,8 @@ const handlerEnvFileName = "HandlerEnvironment.json"
 type GuestAgentEnvVar string
 
 const (
+	// environment variables are declared here
+	// https://github.com/Azure/azure-vmextension-publishing/wiki/2.0-Partner-Guide-Handler-Design-Details#236-summary
 	GuestAgentEnvVarExtensionVersion     GuestAgentEnvVar = "AZURE_GUEST_AGENT_EXTENSION_VERSION"
 	GuestAgentEnvVarExtensionFullPath    GuestAgentEnvVar = "AZURE_GUEST_AGENT_EXTENSION_PATH"
 	GuestAgentEnvVarConfigSequenceNumber GuestAgentEnvVar = "ConfigSequenceNumber"
@@ -34,6 +36,7 @@ const (
 	GuestAgentEnvVarUpdateFromVersion    GuestAgentEnvVar = "AZURE_GUEST_AGENT_UPDATING_FROM_VERSION"
 	GuestAgentEnvVarDisableCmdExitCode   GuestAgentEnvVar = "AZURE_GUEST_AGENT_DISABLE_CMD_EXIT_CODE"
 	GuestAgentEnvVarUninstallCmdExitCode GuestAgentEnvVar = "AZURE_GUEST_AGENT_UNINSTALL_CMD_EXIT_CODE"
+	// environment variables that are for multiconfig extensions are excluded
 )
 
 type OperationName string

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -30,9 +30,10 @@ const (
 	GuestAgentEnvVarExtensionVersion     GuestAgentEnvVar = "AZURE_GUEST_AGENT_EXTENSION_VERSION"
 	GuestAgentEnvVarExtensionFullPath    GuestAgentEnvVar = "AZURE_GUEST_AGENT_EXTENSION_PATH"
 	GuestAgentEnvVarConfigSequenceNumber GuestAgentEnvVar = "ConfigSequenceNumber"
-	GuestAgentEnvVarConfigExtensionName  GuestAgentEnvVar = "ConfigExtensionName"
 	GuestAgentEnvVarUpdateToVersion      GuestAgentEnvVar = "VERSION"
 	GuestAgentEnvVarUpdateFromVersion    GuestAgentEnvVar = "AZURE_GUEST_AGENT_UPDATING_FROM_VERSION"
+	GuestAgentEnvVarDisableCmdExitCode   GuestAgentEnvVar = "AZURE_GUEST_AGENT_DISABLE_CMD_EXIT_CODE"
+	GuestAgentEnvVarUninstallCmdExitCode GuestAgentEnvVar = "AZURE_GUEST_AGENT_UNINSTALL_CMD_EXIT_CODE"
 )
 
 type OperationName string

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -21,7 +21,11 @@ import (
 
 // HandlerEnvFileName is the file name of the Handler Environment as placed by the
 // Azure Guest Agent.
-const handlerEnvFileName = "HandlerEnvironment.json"
+const (
+	handlerEnvFileName          = "HandlerEnvironment.json"
+	ExtensionVersionEnvVarName  = "AZURE_GUEST_AGENT_EXTENSION_VERSION"
+	ExtensionFullPathEnvVarName = "AZURE_GUEST_AGENT_EXTENSION_PATH"
+)
 
 type OperationName string
 
@@ -126,6 +130,22 @@ func (em *prodGetVMExtensionEnvironmentManager) GetHandlerSettings(el logging.IL
 
 func (*prodGetVMExtensionEnvironmentManager) SetSequenceNumberInternal(extensionName, extensionVersion string, seqNo uint) error {
 	return seqno.SetSequenceNumber(extensionName, extensionVersion, seqNo)
+}
+
+func GetExtensionVersionFromEnvironmentVariable() (string, error) {
+	extensionVersion, isSet := os.LookupEnv(ExtensionVersionEnvVarName)
+	if !isSet || extensionVersion == "" {
+		return "", errors.Errorf("Extension version is not set in environment variable '%s'", ExtensionFullPathEnvVarName)
+	}
+	return extensionVersion, nil
+}
+
+func GetExtensionFullPathFromEnvironmentVariable() (string, error) {
+	extensionDirPath, isSet := os.LookupEnv(ExtensionFullPathEnvVarName)
+	if !isSet || extensionDirPath == "" {
+		return "", errors.Errorf("Extension path is not set in environment variable '%s'", ExtensionFullPathEnvVarName)
+	}
+	return extensionDirPath, nil
 }
 
 // GetVMExtension returns a new VMExtension object

--- a/vmextension/vmextension.go
+++ b/vmextension/vmextension.go
@@ -21,10 +21,18 @@ import (
 
 // HandlerEnvFileName is the file name of the Handler Environment as placed by the
 // Azure Guest Agent.
+const handlerEnvFileName = "HandlerEnvironment.json"
+
+// GuestAgentEnvVar represents environment variable names set by the Azure Guest Agent.
+type GuestAgentEnvVar string
+
 const (
-	handlerEnvFileName          = "HandlerEnvironment.json"
-	ExtensionVersionEnvVarName  = "AZURE_GUEST_AGENT_EXTENSION_VERSION"
-	ExtensionFullPathEnvVarName = "AZURE_GUEST_AGENT_EXTENSION_PATH"
+	GuestAgentEnvVarExtensionVersion     GuestAgentEnvVar = "AZURE_GUEST_AGENT_EXTENSION_VERSION"
+	GuestAgentEnvVarExtensionFullPath    GuestAgentEnvVar = "AZURE_GUEST_AGENT_EXTENSION_PATH"
+	GuestAgentEnvVarConfigSequenceNumber GuestAgentEnvVar = "ConfigSequenceNumber"
+	GuestAgentEnvVarConfigExtensionName  GuestAgentEnvVar = "ConfigExtensionName"
+	GuestAgentEnvVarUpdateToVersion      GuestAgentEnvVar = "VERSION"
+	GuestAgentEnvVarUpdateFromVersion    GuestAgentEnvVar = "AZURE_GUEST_AGENT_UPDATING_FROM_VERSION"
 )
 
 type OperationName string
@@ -132,20 +140,12 @@ func (*prodGetVMExtensionEnvironmentManager) SetSequenceNumberInternal(extension
 	return seqno.SetSequenceNumber(extensionName, extensionVersion, seqNo)
 }
 
-func GetExtensionVersionFromEnvironmentVariable() (string, error) {
-	extensionVersion, isSet := os.LookupEnv(ExtensionVersionEnvVarName)
+func GuestAgentEnvironmetVariable(envVarName GuestAgentEnvVar) (string, error) {
+	extensionVersion, isSet := os.LookupEnv(string(envVarName))
 	if !isSet || extensionVersion == "" {
-		return "", errors.Errorf("Extension version is not set in environment variable '%s'", ExtensionFullPathEnvVarName)
+		return "", errors.Errorf("Extension environment variable '%s' is not set", envVarName)
 	}
 	return extensionVersion, nil
-}
-
-func GetExtensionFullPathFromEnvironmentVariable() (string, error) {
-	extensionDirPath, isSet := os.LookupEnv(ExtensionFullPathEnvVarName)
-	if !isSet || extensionDirPath == "" {
-		return "", errors.Errorf("Extension path is not set in environment variable '%s'", ExtensionFullPathEnvVarName)
-	}
-	return extensionDirPath, nil
 }
 
 // GetVMExtension returns a new VMExtension object

--- a/vmextension/vmextension_test.go
+++ b/vmextension/vmextension_test.go
@@ -723,3 +723,43 @@ func cleanupDirsForVMExtension(vmExt *VMExtension) (combinedError error) {
 	combinedError = extensionerrors.CombineErrors(combinedError, os.RemoveAll(vmExt.HandlerEnv.DataFolder))
 	return
 }
+
+func Test_GetExtensionVersionFromEnvironmentVariable_ReturnsVersion(t *testing.T) {
+	t.Setenv(ExtensionVersionEnvVarName, "1.2.3")
+	version, err := GetExtensionVersionFromEnvironmentVariable()
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3", version)
+}
+
+func Test_GetExtensionVersionFromEnvironmentVariable_NotSet(t *testing.T) {
+	t.Setenv(ExtensionVersionEnvVarName, "")
+	_, err := GetExtensionVersionFromEnvironmentVariable()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ExtensionFullPathEnvVarName)
+}
+
+func Test_GetExtensionVersionFromEnvironmentVariable_Unset(t *testing.T) {
+	os.Unsetenv(ExtensionVersionEnvVarName)
+	_, err := GetExtensionVersionFromEnvironmentVariable()
+	require.Error(t, err)
+}
+
+func Test_GetExtensionFullPathFromEnvironmentVariable_ReturnsPath(t *testing.T) {
+	t.Setenv(ExtensionFullPathEnvVarName, "/opt/extensions/myext")
+	path, err := GetExtensionFullPathFromEnvironmentVariable()
+	require.NoError(t, err)
+	require.Equal(t, "/opt/extensions/myext", path)
+}
+
+func Test_GetExtensionFullPathFromEnvironmentVariable_NotSet(t *testing.T) {
+	t.Setenv(ExtensionFullPathEnvVarName, "")
+	_, err := GetExtensionFullPathFromEnvironmentVariable()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ExtensionFullPathEnvVarName)
+}
+
+func Test_GetExtensionFullPathFromEnvironmentVariable_Unset(t *testing.T) {
+	os.Unsetenv(ExtensionFullPathEnvVarName)
+	_, err := GetExtensionFullPathFromEnvironmentVariable()
+	require.Error(t, err)
+}

--- a/vmextension/vmextension_test.go
+++ b/vmextension/vmextension_test.go
@@ -724,42 +724,22 @@ func cleanupDirsForVMExtension(vmExt *VMExtension) (combinedError error) {
 	return
 }
 
-func Test_GetExtensionVersionFromEnvironmentVariable_ReturnsVersion(t *testing.T) {
-	t.Setenv(ExtensionVersionEnvVarName, "1.2.3")
-	version, err := GetExtensionVersionFromEnvironmentVariable()
+func Test_GuestAgentEnvironmentVariable_ReturnsValue(t *testing.T) {
+	t.Setenv(string(GuestAgentEnvVarExtensionVersion), "1.2.3")
+	version, err := GuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
 	require.NoError(t, err)
 	require.Equal(t, "1.2.3", version)
 }
 
-func Test_GetExtensionVersionFromEnvironmentVariable_NotSet(t *testing.T) {
-	t.Setenv(ExtensionVersionEnvVarName, "")
-	_, err := GetExtensionVersionFromEnvironmentVariable()
+func Test_GuestAgentEnvironmentVariable_EmptyValue(t *testing.T) {
+	t.Setenv(string(GuestAgentEnvVarExtensionVersion), "")
+	_, err := GuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), ExtensionFullPathEnvVarName)
+	require.Contains(t, err.Error(), string(GuestAgentEnvVarExtensionVersion))
 }
 
-func Test_GetExtensionVersionFromEnvironmentVariable_Unset(t *testing.T) {
-	os.Unsetenv(ExtensionVersionEnvVarName)
-	_, err := GetExtensionVersionFromEnvironmentVariable()
-	require.Error(t, err)
-}
-
-func Test_GetExtensionFullPathFromEnvironmentVariable_ReturnsPath(t *testing.T) {
-	t.Setenv(ExtensionFullPathEnvVarName, "/opt/extensions/myext")
-	path, err := GetExtensionFullPathFromEnvironmentVariable()
-	require.NoError(t, err)
-	require.Equal(t, "/opt/extensions/myext", path)
-}
-
-func Test_GetExtensionFullPathFromEnvironmentVariable_NotSet(t *testing.T) {
-	t.Setenv(ExtensionFullPathEnvVarName, "")
-	_, err := GetExtensionFullPathFromEnvironmentVariable()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), ExtensionFullPathEnvVarName)
-}
-
-func Test_GetExtensionFullPathFromEnvironmentVariable_Unset(t *testing.T) {
-	os.Unsetenv(ExtensionFullPathEnvVarName)
-	_, err := GetExtensionFullPathFromEnvironmentVariable()
+func Test_GuestAgentEnvironmentVariable_Unset(t *testing.T) {
+	os.Unsetenv(string(GuestAgentEnvVarExtensionVersion))
+	_, err := GuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
 	require.Error(t, err)
 }

--- a/vmextension/vmextension_test.go
+++ b/vmextension/vmextension_test.go
@@ -726,20 +726,20 @@ func cleanupDirsForVMExtension(vmExt *VMExtension) (combinedError error) {
 
 func Test_GuestAgentEnvironmentVariable_ReturnsValue(t *testing.T) {
 	t.Setenv(string(GuestAgentEnvVarExtensionVersion), "1.2.3")
-	version, err := GuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
+	version, err := GetGuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
 	require.NoError(t, err)
 	require.Equal(t, "1.2.3", version)
 }
 
 func Test_GuestAgentEnvironmentVariable_EmptyValue(t *testing.T) {
 	t.Setenv(string(GuestAgentEnvVarExtensionVersion), "")
-	_, err := GuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
+	_, err := GetGuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), string(GuestAgentEnvVarExtensionVersion))
 }
 
 func Test_GuestAgentEnvironmentVariable_Unset(t *testing.T) {
 	os.Unsetenv(string(GuestAgentEnvVarExtensionVersion))
-	_, err := GuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
+	_, err := GetGuestAgentEnvironmetVariable(GuestAgentEnvVarExtensionVersion)
 	require.Error(t, err)
 }


### PR DESCRIPTION
Added function to retrieve Environment variable set by the guest agent.

The environment variables are declared here https://github.com/Azure/azure-vmextension-publishing/wiki/2.0-Partner-Guide-Handler-Design-Details#236-summary

Environment variables that are for multi-config extensions are excluded

Fixed one unrelated flaky test

